### PR TITLE
Update 87869fe7-bc09-4c83-af2c-f5bff2fbba95

### DIFF
--- a/collections/87869fe7-bc09-4c83-af2c-f5bff2fbba95
+++ b/collections/87869fe7-bc09-4c83-af2c-f5bff2fbba95
@@ -1,7 +1,7 @@
 {
     "institution": "Chicago Academy of Sciences, The Peggy Notebaert Nature Museum",
-    "collection": "Vertebrates",
-    "recordsets": "d2e1d686-7e52-410a-8755-78e9f60376a7",
+    "collection": "Mammals",
+    "recordsets": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
     "institution_code": "CHAS",
     "collection_code": "",
     "collection_uuid": "urn:uuid:87869fe7-bc09-4c83-af2c-f5bff2fbba95",


### PR DESCRIPTION
update CHAS vertebrates recordID - the previous link is defunct, plus they subdivided their collection differently, it is now 'mammals', not 'vertebrates'