### PR TITLE
Update f8dc372c-6742-49a2-a602-78a352adfc15

### DIFF
--- a/collections/f8dc372c-6742-49a2-a602-78a352adfc15
+++ b/collections/f8dc372c-6742-49a2-a602-78a352adfc15
@@ -8,7 +8,7 @@
     "collection_lsid": "urn:lsid:biocol.org:col:15210",
     "collection_url": "http://www.brown.edu/research/projects/herbarium/",
     "collection_catalog_url": "",
-    "contact": "Thimothy Whitfield",
+    "contact": "Timothy Whitfeld",
     "contact_role": "Collections Manager",
     "contact_email": "Timothy_Whitfield@brown.edu",
     "taxonomic_coverage": "",


### PR DESCRIPTION
Brown University BRU: fixed typo in Tim Whitfeld's name