### PR TITLE
Update db8c793d-75f3-4663-b3db-2d2f6a79f5db

### DIFF
--- a/collections/db8c793d-75f3-4663-b3db-2d2f6a79f5db
+++ b/collections/db8c793d-75f3-4663-b3db-2d2f6a79f5db
@@ -13,7 +13,7 @@
 	"descriptionForSpecialists": "",
 	"cataloguedSpecimens": 7710,
 	"knownToContainTypes": false,
-	"taxonCoverage": "Thayer Bird Collection - this mount collection contains around 3,000 specimens from around the world collected from approximately 880-1920 - this collections contains numerous extinct and endangered specimens.  Worcester Herbarium Collection - Several thousand local herbarium sheets collected between 1890-1940.",
+	"taxonCoverage": "Thayer Bird Collection - this mount collection contains around 3,000 specimens from around the world collected from approximately 1880-1920 - this collections contains numerous extinct and endangered specimens.  Worcester Herbarium Collection - Several thousand local herbarium sheets collected between 1890-1940.",
 	"geographic_range": "The collection has world wide geographic focus.  The exception being the herbarium collection which is specific to Worcester County. ",
 	"collectionExtent": "",
 	"contact": "Shana Hawrylchak",


### PR DESCRIPTION
fixed typo according to Shana. Missing leading '1' in date in Description.