### PR TITLE
Update cf776df9-99bb-49b9-a106-888ffeec2924

### DIFF
--- a/collections/cf776df9-99bb-49b9-a106-888ffeec2924
+++ b/collections/cf776df9-99bb-49b9-a106-888ffeec2924
@@ -1,8 +1,8 @@
 {
     "institution": "University of Nebraska Lincoln, University of Nebraska State Museum",
     "collection": "Division of Entomology",
-    "recordsets": "f83517ea-7b9f-443d-9371-d11a05ebc0a7",
-    "recordsetQuery": "{\"recordset\":\"f83517ea-7b9f-443d-9371-d11a05ebc0a7\"}",
+    "recordsets": "",
+    "recordsetQuery": "",
     "institution_code": "UNSM",
     "collection_code": "UNSM",
     "collection_uuid": "urn:uuid:cf776df9-99bb-49b9-a106-888ffeec2924",


### PR DESCRIPTION
removed recordset UUID - it does not exist anywhere in our system - portal/publishers page, TCN/PEN Access DB. Oddly, it shows up on this page: https://www.idigbio.org/wiki/index.php/IDigBio_API_v1_Examples#idigbio:links_and_the_20_Item_List